### PR TITLE
Integrate Coveralls, Code Climate and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 node_modules
 npm-debug.log
 privateFiles
+.nyc_output
+coverage
+.coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+
+node_js:
+  - 6.10.1
+  - 6.10.2
+
+before_script:
+  - npm install
+
+script: 
+  - npm test
+
+after_success:
+  - npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/andela-foladipo/news-flash-cp1/badge.svg?branch=develop)](https://coveralls.io/github/andela-foladipo/news-flash-cp1?branch=develop)
+
 # Welcome
 
 Welcome to News Flash! This project gives you access to high quality, cutting edge news from 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+[![Build Status](https://travis-ci.org/andela-foladipo/news-flash-cp1.svg?branch=develop)](https://travis-ci.org/andela-foladipo/news-flash-cp1)
+
 [![Coverage Status](https://coveralls.io/repos/github/andela-foladipo/news-flash-cp1/badge.svg?branch=develop)](https://coveralls.io/github/andela-foladipo/news-flash-cp1?branch=develop)
+
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg)]()
+
+[![Code Climate](https://codeclimate.com/github/andela-foladipo/news-flash-cp1//badges/gpa.svg)](https://codeclimate.com/github/andela-foladipo/news-flash-cp1/)
 
 # Welcome
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 [![Build Status](https://travis-ci.org/andela-foladipo/news-flash-cp1.svg?branch=develop)](https://travis-ci.org/andela-foladipo/news-flash-cp1)
-
 [![Coverage Status](https://coveralls.io/repos/github/andela-foladipo/news-flash-cp1/badge.svg?branch=develop)](https://coveralls.io/github/andela-foladipo/news-flash-cp1?branch=develop)
-
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)]()
-
 [![Code Climate](https://codeclimate.com/github/andela-foladipo/news-flash-cp1//badges/gpa.svg)](https://codeclimate.com/github/andela-foladipo/news-flash-cp1/)
 
 # Welcome

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "A web app that retrieves news headlines and displays them in a list.",
   "main": "app.js",
   "scripts": {
+    "build": "./node_modules/.bin/webpack",
+    "build:watch": "./node_modules/.bin/webpack --watch",
+    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls",
     "start": "node app.js",
     "test": "./node_modules/.bin/mocha --require babel-register tests/.setup.js tests/*[sS]pec.js",
-    "build": "./node_modules/.bin/webpack",
-    "build:watch": "./node_modules/.bin/webpack --watch"
+    "test:nyc": "./node_modules/.bin/nyc --reporter=html --reporter=text ./node_modules/.bin/mocha --require babel-register tests/.setup.js tests/*[sS]pec.js"
   },
   "repository": {
     "type": "git",
@@ -41,6 +43,7 @@
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "cheerio": "^0.22.0",
+    "coveralls": "^2.13.0",
     "css-loader": "^0.28.0",
     "dotenv": "^4.0.0",
     "enzyme": "^2.8.1",
@@ -54,6 +57,7 @@
     "mocha": "^3.2.0",
     "morgan": "^1.8.1",
     "node-sass": "^4.5.2",
+    "nyc": "^10.2.0",
     "react-addons-test-utils": "^15.5.1",
     "react-test-renderer": "^15.5.4",
     "sass-loader": "^6.0.3",


### PR DESCRIPTION
#### What does this PR do?
Integrates Coveralls, Code Climate, Travis and the MIT License and shows badges from these tools in the project README.

#### Description of task to be completed?
Add badges for Coveralls, Code Climate, Travis and the MIT License.

#### How should this be manually tested?
Switch to the `chore/ZY3AgsQe/create-project-readme` branch of this repo. The project `README.md` will have badges from Coveralls, Code Climate, Travis and the MIT License.

#### Any background context you want to provide?
N/A

#### What are the relevant Trello cards?
https://trello.com/c/ZY3AgsQe


#### Screenshots
<img width="668" alt="screen shot 2017-04-27 at 9 11 44 pm" src="https://cloud.githubusercontent.com/assets/26963575/25502339/2b96e0ce-2b8e-11e7-96b9-d7754470e3bf.png">

